### PR TITLE
Call setDebugLog before setMinTimeBetweenSessions

### DIFF
--- a/java/basic_app/app/src/main/java/com/appsflyer/onelink/appsflyeronelinkbasicapp/AppsflyerBasicApp.java
+++ b/java/basic_app/app/src/main/java/com/appsflyer/onelink/appsflyeronelinkbasicapp/AppsflyerBasicApp.java
@@ -24,8 +24,9 @@ public class AppsflyerBasicApp extends Application {
         super.onCreate();
         String afDevKey = AppsFlyerConstants.afDevKey;
         AppsFlyerLib appsflyer = AppsFlyerLib.getInstance();
-        appsflyer.setMinTimeBetweenSessions(0);
+        // Make sure you remove the following line when building to production
         appsflyer.setDebugLog(true);
+        appsflyer.setMinTimeBetweenSessions(0);
 
         appsflyer.subscribeForDeepLink(new DeepLinkListener(){
             @Override


### PR DESCRIPTION
Added comment to remove setDebugLog(true) from production builds.